### PR TITLE
Add lecture 1 requested fixes patch

### DIFF
--- a/patches/lecture1_requested_fixes.patch
+++ b/patches/lecture1_requested_fixes.patch
@@ -2,17 +2,15 @@ diff --git a/tex/lecture1.tex b/tex/lecture1.tex
 index 26560fb..0000000 100644
 --- a/tex/lecture1.tex
 +++ b/tex/lecture1.tex
-@@ -122,7 +122,7 @@
+@@ -121,6 +121,6 @@
+   The set $\Lambda(V)$ of $\lambda$-terms over $V$ is defined \emph{inductively} as
    \begin{description}
      \item[variable] $x \in \Lambda(V)$ if $x$ is in $V$
      \item[application] $t@u \in \Lambda(V)$ if $t, u \in \Lambda(V)$
 -    \item[abstraction] $\lam{x}t$ if $x \in V$ and $t \in \Lambda(V)$
 +    \item[abstraction] $\lam{x}t \in \Lambda(V)$ if $x \in V$ and $t \in \Lambda(V)$
    \end{description}
- 
-   \vfill
-@@ -236,10 +236,9 @@
-     \end{prooftree}
+@@ -237,8 +237,7 @@
      \qquad
      \begin{prooftree}
 -      \AxiomC{$x \in V$}
@@ -23,17 +21,12 @@ index 26560fb..0000000 100644
 +      \UnaryInfC{$\lambda x.\, t \in \Lambda(V)$}
      \end{prooftree}
  \end{frame}
- 
-@@ -277,8 +276,7 @@
- \end{frame}
- 
+@@ -279,4 +278,3 @@
  \begin{frame}{Exercises}
 -    Assuming, $a$, $b$, $x$, $y$, and $z$ are all in $V$, derive the following
 -    terms using its formation rules.  That is, show that the following are
 +    Assume that all variables appearing below are in $V$. Derive the following terms using their formation rules. That is, show that the following are
      valid $\lambda$-terms.
-     \begin{enumerate}
-       \item $x\,@\,(y\,@\,z)$
 @@ -298,7 +296,7 @@
  \begin{frame}{The need for some conventions}
    For arithmetic expressions, we typically write
@@ -43,7 +36,7 @@ index 26560fb..0000000 100644
    \]
    by the precedence convention.
    \vfill
-@@ -536,7 +534,7 @@
+@@ -534,7 +532,7 @@
                child {node {$@$}
                  child {node (x) {$1$}}
                  child {node (y) {$0$}}
@@ -52,16 +45,13 @@ index 26560fb..0000000 100644
 +              child {node {$z$}}
              }
            };
- 
-@@ -649,7 +647,7 @@
+@@ -649,5 +647,5 @@
  
  \begin{frame}{Variable permutation}
    \begin{alertblock}{Idea}
 -    We rename a variable $x$ in $t$ with a fresh variable $z$ to $x$, i.e.\ $z \not\in \Var(t)$.
 +    To rename a binder safely, we swap it with a fresh variable $z \notin \Var(t)$.
    \end{alertblock}
-   
-   A \emph{transposition} $(x\, y)$ is a function that swaps $x$ and $y$ but fixes everything else, i.e.\
 @@ -661,7 +659,7 @@
        z & \text{otherwise}
      \end{cases}
@@ -80,8 +70,7 @@ index 26560fb..0000000 100644
      \UIC{$\lam{x}t \mathrel{=_\alpha} \lam{y}u $}
    \end{prooftree}
    \end{definition}
-@@ -916,7 +914,11 @@
-   \end{multicols}
+@@ -916,4 +914,9 @@
  \end{definition}
  For example, 
 -  $(\boxed{(\lam{x y}x)\; t})\;u \onereduce \boxed{(\lam{y}t)\;u} \onereduce t\subst{u}{y}$.
@@ -92,21 +81,14 @@ index 26560fb..0000000 100644
 +    \qquad\text{assuming } y \notin \FV(t).
 +  \]
  \end{frame}
- 
-@@ -964,12 +966,11 @@
-   We often say ``if $t \reduce u$ and $u \reduce v$ then $t \reduce v$'' instead.
+@@ -964,5 +968,5 @@
    \begin{proof}
      By induction on the derivation $d$ of $t \reduce u$:
      \begin{enumerate}
 -      \item If $d$ is given by (0-step), then $t =_\alpha u$.
 +      \item If $d$ is given by (0-step), then $u = t$, so the given derivation of $u \reduce v$ is already a derivation of $t \reduce v$.
        \item If $d$ is given by (n+1-step), i.e.\ there is $u'$ s.t.\ 
-         $t \onereduce u'$ and $u' \reduce u$.
- 
-         By induction hypothesis,
-         every derivation $u' \reduce u$ gives rise to a derivation of $u' \reduce v$, so by (n+1-step) $t \reduce v$. 
-@@ -990,8 +991,41 @@
-   How about the converse?
+@@ -990,7 +994,46 @@
  \end{frame}
  
  \begin{frame}{Summary}

--- a/patches/lecture1_requested_fixes.patch
+++ b/patches/lecture1_requested_fixes.patch
@@ -1,0 +1,156 @@
+diff --git a/tex/lecture1.tex b/tex/lecture1.tex
+index 26560fb..0000000 100644
+--- a/tex/lecture1.tex
++++ b/tex/lecture1.tex
+@@ -122,7 +122,7 @@
+   \begin{description}
+     \item[variable] $x \in \Lambda(V)$ if $x$ is in $V$
+     \item[application] $t@u \in \Lambda(V)$ if $t, u \in \Lambda(V)$
+-    \item[abstraction] $\lam{x}t$ if $x \in V$ and $t \in \Lambda(V)$
++    \item[abstraction] $\lam{x}t \in \Lambda(V)$ if $x \in V$ and $t \in \Lambda(V)$
+   \end{description}
+ 
+   \vfill
+@@ -236,10 +236,9 @@
+     \end{prooftree}
+     \qquad
+     \begin{prooftree}
+-      \AxiomC{$x \in V$}
+       \AxiomC{$t \in \Lambda(V)$}
+-      \RightLabel{\textsc{Abs}}
+-      \BinaryInfC{$\lambda x.\, t \in \Lambda(V)$}
++      \RightLabel{\textsc{Abs}, $x \in V$}
++      \UnaryInfC{$\lambda x.\, t \in \Lambda(V)$}
+     \end{prooftree}
+ \end{frame}
+ 
+@@ -277,8 +276,7 @@
+ \end{frame}
+ 
+ \begin{frame}{Exercises}
+-    Assuming, $a$, $b$, $x$, $y$, and $z$ are all in $V$, derive the following
+-    terms using its formation rules.  That is, show that the following are
++    Assume that all variables appearing below are in $V$. Derive the following terms using their formation rules. That is, show that the following are
+     valid $\lambda$-terms.
+     \begin{enumerate}
+       \item $x\,@\,(y\,@\,z)$
+@@ -298,7 +296,7 @@
+ \begin{frame}{The need for some conventions}
+   For arithmetic expressions, we typically write
+   \[
+-    3 * 4 + 7 *2 \qquad\text{to mean}\qquad (3 * 4) + (7 + 2)
++    3 * 4 + 7 *2 \qquad\text{to mean}\qquad (3 * 4) + (7 * 2)
+   \]
+   by the precedence convention.
+   \vfill
+@@ -536,7 +534,7 @@
+               child {node {$@$}
+                 child {node (x) {$1$}}
+                 child {node (y) {$0$}}
+               }
+-              child {node {$3$}}
++              child {node {$z$}}
+             }
+           };
+ 
+@@ -649,7 +647,7 @@
+ 
+ \begin{frame}{Variable permutation}
+   \begin{alertblock}{Idea}
+-    We rename a variable $x$ in $t$ with a fresh variable $z$ to $x$, i.e.\ $z \not\in \Var(t)$.
++    To rename a binder safely, we swap it with a fresh variable $z \notin \Var(t)$.
+   \end{alertblock}
+   
+   A \emph{transposition} $(x\, y)$ is a function that swaps $x$ and $y$ but fixes everything else, i.e.\
+@@ -661,7 +659,7 @@
+       z & \text{otherwise}
+     \end{cases}
+   \]
+-   The \emph{variable permutation} by a transportation $\pi = (y\,z)$ is defined by
++   The \emph{variable permutation} by a transposition $\pi = (y\,z)$ is defined by
+    \begin{align*}
+      \pi\cdot x     & = \pi\;x \\
+      \pi\cdot(t\;u) & = (\pi\cdot t)\; (\pi\cdot u) \\
+@@ -690,7 +688,7 @@
+   \end{multicols}
+   \begin{prooftree}
+     \AXC{$(z\;x)\cdot t \mathrel{=_\alpha} (z\;y)\cdot u$}
+-    \RightLabel{if $z \not\in \Var(t, u)$}
++    \RightLabel{if $z \not\in \Var(t) \cup \Var(u)$}
+     \UIC{$\lam{x}t \mathrel{=_\alpha} \lam{y}u $}
+   \end{prooftree}
+   \end{definition}
+@@ -916,7 +914,11 @@
+   \end{multicols}
+ \end{definition}
+ For example, 
+-  $(\boxed{(\lam{x y}x)\; t})\;u \onereduce \boxed{(\lam{y}t)\;u} \onereduce t\subst{u}{y}$.
++  \[
++    (\boxed{(\lam{x\,y}x)\; t})\;u
++    \onereduce (\lam{y}t)\;u
++    \onereduce t
++    \qquad\text{assuming } y \notin \FV(t).
++  \]
+ \end{frame}
+ 
+@@ -964,12 +966,11 @@
+   We often say ``if $t \reduce u$ and $u \reduce v$ then $t \reduce v$'' instead.
+   \begin{proof}
+     By induction on the derivation $d$ of $t \reduce u$:
+     \begin{enumerate}
+-      \item If $d$ is given by (0-step), then $t =_\alpha u$.
++      \item If $d$ is given by (0-step), then $u = t$, so the given derivation of $u \reduce v$ is already a derivation of $t \reduce v$.
+       \item If $d$ is given by (n+1-step), i.e.\ there is $u'$ s.t.\ 
+         $t \onereduce u'$ and $u' \reduce u$.
+ 
+         By induction hypothesis,
+         every derivation $u' \reduce u$ gives rise to a derivation of $u' \reduce v$, so by (n+1-step) $t \reduce v$. 
+@@ -990,8 +991,41 @@
+   How about the converse?
+ \end{frame}
+ 
+ \begin{frame}{Summary}
+-  SUMMARISE HERE ALL THE RELATIONS WE HAVE SEEN SO FAR.
++  \begin{description}
++    \item[Term formation]
++      \[
++        x \in \Lambda(V)
++        \qquad
++        t @ u \in \Lambda(V)
++        \qquad
++        \lambda x.\,t \in \Lambda(V)
++      \]
++
++    \item[$\alpha$-equivalence]
++      $t =_\alpha u$ means that $t$ and $u$ have the same binding structure,
++      up to renaming of bound variables.
++
++    \item[Variables]
++      \[
++        \Var(t) \quad\text{all variables occurring in } t,
++        \qquad
++        \FV(t) \quad\text{free variables of } t.
++      \]
++
++    \item[Substitution]
++      $t\subst{u}{x}$ denotes capture-avoiding substitution of $u$ for $x$ in $t$.
++
++    \item[One-step reduction]
++      \[
++        t \onereduce u
++      \]
++      means that $t$ reduces to $u$ by one full $\beta$-reduction step.
++
++    \item[Multi-step reduction]
++      \[
++        t \reduce u
++      \]
++      means that $t$ reduces to $u$ by zero or more full $\beta$-reduction steps.
++
++    \item[$\beta$-equality]
++      $t =_\beta u$ is the symmetric, reflexive, transitive closure of one-step
++      $\beta$-reduction.
++  \end{description}
+ \end{frame}
+ 
+ \end{document}


### PR DESCRIPTION
Adds a unified patch file for the requested Lecture 1 fixes. The patch updates the formation rule presentation, exercise wording, de Bruijn free-variable display, beta-reduction example, alpha-equivalence side condition, variable-permutation wording, transitivity proof, and summary frame. Apply the patch from the repository root using git apply patches/lecture1_requested_fixes.patch.